### PR TITLE
Python docker + argument token instead of interactive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM archlinux
+FROM python:3-alpine
 
 WORKDIR /asca/
 
-RUN pacman -Syu python python-pip git --noconfirm && \
-    git clone https://github.com/Qxe5/asca.git . && \
-    python -m pip install -r requirements.txt --no-cache-dir
+RUN apk update && apk add git && \
+    git clone https://github.com/Qxe5/asca . && \
+    pip install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT python bot.py
+ENTRYPOINT [ "python", "./bot.py" ]

--- a/README.md
+++ b/README.md
@@ -30,8 +30,13 @@ Both modes of operation require `Manage Messages` to delete scam messages
 % python3 -m pip install --requirement requirements.txt
 % python3 bot.py
 ```
-
-[Docker](https://hub.docker.com/r/dotbotio/asca)
+   
+Docker:
+```
+% docker volume create asca
+% docker run -d -v asca:/asca/database/ dotbotio/asca <bottoken>
+```
+[Docker image](https://hub.docker.com/r/dotbotio/asca)
 </details>
 
 <details>

--- a/bot.py
+++ b/bot.py
@@ -136,6 +136,7 @@ async def stoplog_error(ctx, error):
 # add cogs
 bot.add_cog(Status(bot))
 
+'''
 # authenticate
 token = getpass(prompt='Token: ')
 
@@ -144,3 +145,10 @@ try:
 except discord.LoginFailure as loginfailure:
     print('Invalid Token')
     raise SystemExit(1) from loginfailure
+'''
+
+if len(sys.argv) < 2:
+    print("Usage: ./bot.py <token>")
+
+bot.run(sys.argv[1])
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+services:
+
+  asca:
+    image: dotbotio/asca
+    container_name: asca
+    restart: always
+    command: <bottoken> #replace <bottoken> with the token of the bot.
+    volumes:
+      - asca:/asca/database/
+
+volumes:
+    asca:
+        external: false


### PR DESCRIPTION
Was testing the bot out in docker and ran into some issues/annoyance but might just be my lack of understanding docker properly.

This pull request will switch the Dockerfile to the official python alpine image making it smaller in size.
Adjusted bot.py to be usable with "./bot.py <token>" so it doesn't has to stay interactive allowing you to run the docker container in the background too.